### PR TITLE
Elixir:  disable unnecssesary_quotes warning

### DIFF
--- a/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
+++ b/modules/openapi-generator/src/main/resources/elixir/mix.exs.mustache
@@ -7,6 +7,7 @@ defmodule {{moduleName}}.Mixfile do
      elixir: "~> {{supportedElixirVersion}}",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
+     elixirc_options: [parser_options: [warn_on_unnecessary_quotes: false]],
      deps: deps()]
   end
 


### PR DESCRIPTION
The code generator always creates quoted atoms.
elixirc will output a warning if those quotes are not strictly necessary.
set a parser option to disable this warning for the generated code.

